### PR TITLE
Null check for publish tokens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,20 +147,26 @@ unifiedPublishing {
 
         mainPublication tasks.remapJar // Declares the publicated jar
 
-        curseforge {
-            token = System.getenv("CURSE_TOKEN")
-            id = "881778" // Required, must be a string, ID of CurseForge project
+        var cfToken = System.getenv("CURSE_TOKEN")
+        if (cfToken != null) {
+            curseforge {
+                token = cfToken
+                id = "881778" // Required, must be a string, ID of CurseForge project
 
-            relations { // Optional, Inferred from the relations above by default
+                relations { // Optional, Inferred from the relations above by default
+                }
             }
         }
 
-        modrinth {
-            token = System.getenv("MODRINTH_TOKEN")
-            id = "HBIG5nRf" // Required, must be a string, ID of Modrinth project
-            displayName = project.mod_version
+        var mrToken = System.getenv("MODRINTH_TOKEN")
+        if (mrToken != null) {
+            modrinth {
+                token = mrToken
+                id = "HBIG5nRf" // Required, must be a string, ID of Modrinth project
+                displayName = project.mod_version
 
-            relations { // Optional, Inferred from the relations above by default
+                relations { // Optional, Inferred from the relations above by default
+                }
             }
         }
     }


### PR DESCRIPTION
This also fixes [Jade#299](https://github.com/Snownee/Jade/issues/299).

For [proxy arguments](https://github.com/Snownee/Jade/issues/299#issuecomment-1708144093), moving them to C:/Users/UserName/.gradle/gradle.properties (Or your custom gradle home) may help.