### PR TITLE
fix: add mapped name to `textanimator$removeRainbowForBorder`

### DIFF
--- a/src/main/java/snownee/textanimator/mixin/client/FontMixin.java
+++ b/src/main/java/snownee/textanimator/mixin/client/FontMixin.java
@@ -14,7 +14,7 @@ import snownee.textanimator.effect.RainbowEffect;
 @Mixin(Font.class)
 public class FontMixin {
 	@ModifyExpressionValue(
-			method = "lambda$drawInBatch8xOutline$1",
+			method = {"lambda$drawInBatch8xOutline$1", "m_168654_", "method_37297"},
 			at = @At(
 					value = "INVOKE",
 					target = "Lnet/minecraft/network/chat/Style;withColor(I)Lnet/minecraft/network/chat/Style;"


### PR DESCRIPTION
fix #18