### PR TITLE
Fix client crashes in RainbowEffect and ShakeEffect

### DIFF
--- a/src/main/java/snownee/textanimator/TextAnimatorClient.java
+++ b/src/main/java/snownee/textanimator/TextAnimatorClient.java
@@ -70,7 +70,7 @@ public class TextAnimatorClient {
 	}
 
 	public static Vec2 getRandomDirection(int seed) {
-		return RANDOM_DIR[Math.abs(seed) % RANDOM_DIR.length];
+		return RANDOM_DIR[Math.floorMod(seed, RANDOM_DIR.length)];
 	}
 
 	public static void renderNeonEffect(

--- a/src/main/java/snownee/textanimator/effect/RainbowEffect.java
+++ b/src/main/java/snownee/textanimator/effect/RainbowEffect.java
@@ -18,7 +18,9 @@ public class RainbowEffect extends BaseEffect {
 		if (settings.isShadow) {
 			return;
 		}
-		int color = Mth.hsvToRgb(((Util.getMillis() * 0.02F * speed + settings.index * phase) % 30) / 30, 0.8F, 0.8F);
+		float hue = ((Util.getMillis() * 0.02F * speed + settings.index * phase) % 30) / 30;
+		hue = (hue % 1f + 1f) % 1f;
+		int color = Mth.hsvToRgb(hue, 0.8F, 0.8F);
 		settings.r = (color >> 16 & 255) / 255F;
 		settings.g = (color >> 8 & 255) / 255F;
 		settings.b = (color & 255) / 255F;


### PR DESCRIPTION
Fixed client crashes caused by negative frequency/hue inputs in RainbowEffect and index out of bounds in ShakeEffect/getRandomDirection.